### PR TITLE
preamble_insert: offset undefined, changed to d_offset

### DIFF
--- a/lib/preamble_insert_bb_impl.cc
+++ b/lib/preamble_insert_bb_impl.cc
@@ -46,8 +46,8 @@ namespace gr {
         d_data(preamble),
         d_offset(0)
     {
-      assert(offset < width);
-      assert(offset >= 0);
+      assert(d_offset < width);
+      assert(d_offset >= 0);
       assert((size_t)width > preamble.size());
       set_width(width);
     }


### PR DESCRIPTION
This compiles fine on my machine, but failed on another. Fixed the error.
