### PR TITLE
gr-mapper: create and install pkgconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,32 @@ if(NOT Boost_FOUND)
     message(FATAL_ERROR "Boost required to compile mapper")
 endif()
 
+
+########################################################################
+# Setup the package config file
+########################################################################
+#set variables found in the pc.in file
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix "\${prefix}")
+set(libdir "\${exec_prefix}/lib${LIB_SUFFIX}")
+set(includedir "\${prefix}/include")
+set(grcdir "\${prefix}/share/gnuradio/grc/blocks/")
+set(GR_PKG_DATA_DIR "\${prefix}/share/gnuradio/")
+set(GRC_BLOCKS_DIR      ${GR_PKG_DATA_DIR}/grc/blocks)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/mapper.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/mapper.pc
+@ONLY)
+
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/mapper.pc
+    DESTINATION lib${LIB_SUFFIX}/pkgconfig
+    COMPONENT "mapper_devel"
+)
+
+
 ########################################################################
 # Install directories
 ########################################################################

--- a/mapper.pc.in
+++ b/mapper.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: es
+Description: GNURadio Mapper Interface
+Requires:
+Version: @VERSION@
+Libs: -L${libdir} @BOOST_LDFLAGS@ @BOOST_REGEX_LIB@ -Lgnuradio-mapper
+Cflags: @BOOST_CPPFLAGS@ -I${includedir}
+


### PR DESCRIPTION
This will allow other modules (for example: gr-burst) to find and link
with gr-mapper when installed to different prefix paths.
