### PR TITLE
constellation.c: Fix a gcc6 compile error.

### DIFF
--- a/lib/constellation.cc
+++ b/lib/constellation.cc
@@ -291,7 +291,7 @@ namespace gr {
                
                 // approximate llr from  ln(e^(max(p1))/e^(max(p0)))
                 LLR = (p1 - p0);
-                if(isnan(LLR) || (LLR > 100))
+                if(std::isnan(LLR) || (LLR > 100))
                     LLR = 100.0f;
                 if(LLR < -100)
                     LLR = -100;


### PR DESCRIPTION
lib/constellation.cc:294:25: error: 'isnan' was not declared in this scope
|                  if(isnan(LLR) || (LLR > 100))

Signed-off-by: Philip Balister philip@balister.org
