### PR TITLE
Fix cmake for non lib64 64 bit builds.

### DIFF
--- a/cmake/Modules/GrPlatform.cmake
+++ b/cmake/Modules/GrPlatform.cmake
@@ -29,11 +29,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(LINUX TRUE)
 endif()
 
-if(LINUX AND EXISTS "/etc/debian_version")
+if(NOT CMAKE_CROSSCOMPILING AND LINUX AND EXISTS "/etc/debian_version")
     set(DEBIAN TRUE)
 endif()
 
-if(LINUX AND EXISTS "/etc/redhat-release")
+if(NOT CMAKE_CROSSCOMPILING AND LINUX AND EXISTS "/etc/redhat-release")
     set(REDHAT TRUE)
 endif()
 


### PR DESCRIPTION
If you are cross compiling, you shouldn't make decisions based on build system distribution.
