### PR TITLE
fixing unit power normalization calculation

### DIFF
--- a/lib/constellation.cc
+++ b/lib/constellation.cc
@@ -75,7 +75,7 @@ namespace gr {
                         // normalize constellation power to 1
                         for(int j=0; j< d_wmaps.size(); j++){
                             float avgp = 0;
-                            for(int i=0; i<d_wmaps[j].size(); i++){ avgp = std::sqrt((d_wmaps[j][i] * std::conj(d_wmaps[j][i])).real()); }
+                            for(int i=0; i<d_wmaps[j].size(); i++){ avgp += std::sqrt((d_wmaps[j][i] * std::conj(d_wmaps[j][i])).real()); }
                             float scale = d_wmaps[j].size() / avgp;
                             for(int i=0; i<d_wmaps[j].size(); i++){ d_wmaps[j][i] = d_wmaps[j][i] * scale; }
                         }


### PR DESCRIPTION
when messing with radioml, noticed that the power coming out of the modulation schemes didn't look normalized. 

For instance QAM64
![screenshot from 2016-10-11 13-56-21](https://cloud.githubusercontent.com/assets/4663435/19283120/ca984b70-8fbe-11e6-8ce0-457b0a710d26.png)

I think the issue may be this little typo in the commit. Running radioml datageneration I get more normalized plots now.

![screenshot from 2016-10-11 14-28-17](https://cloud.githubusercontent.com/assets/4663435/19283216/0f99ad18-8fbf-11e6-9543-2974f72dd1e1.png)
